### PR TITLE
Delete `console.log` from `kanji_content_detect.js`

### DIFF
--- a/kanji_content_detect.js
+++ b/kanji_content_detect.js
@@ -8,7 +8,6 @@ var INSERTED_NODE_CHECK_TIMEOUT_ID = null;
 var MUTATION_OBSERVER = null
 var PERSISTENT_MODE
 
-console.log('kanji_content_detect.js executed!')
 // Add an empty onunload function to force run this content_script even when back/forward
 // https://stackoverflow.com/questions/2638292/after-travelling-back-in-firefox-history-javascript-wont-run
 window.addEventListener('unload', function () { })


### PR DESCRIPTION
Every time I open my javascript console, because I have this extension installed, I have a `console.log` statement from this extension. This `console.log` should only really happen if it's useful in debugging whether or not the extension itself has loaded, and even then only in a development environment.