### PR TITLE
Fix same Kanji character not being replaced twice

### DIFF
--- a/background.js
+++ b/background.js
@@ -306,7 +306,7 @@ browser.runtime.onMessage.addListener(
                     // sort tagged in order to add furigana 
                     // for the longer Kanji series first
                     tagged.sort(function(a, b) {
-                        var kanjiRegExp = /([\u4E00-\u9FFF]*)/;
+                        var kanjiRegExp = /([\u3400-\u9FBF]*)/;
                         var aKanji = a.surface.match(kanjiRegExp)[0];
                         var bKanji = b.surface.match(kanjiRegExp)[0];
                         return bKanji.length - aKanji.length;

--- a/background.js
+++ b/background.js
@@ -240,7 +240,7 @@ function addRuby(furiganized, kanji, yomi, key, processed, yomiStyle) {
             // furiganized[key] = furiganized[key].replace(rubyPatt, `<ruby><rb>${kanji}</rb><rp>(</rp><rt style="${yomiStyle}">${yomi}</rt><rp>)</rp></ruby>`);
             furiganized[key] = furiganized[key].replace(rubyPatt, `<ruby><rb>${kanji}</rb><rt style="${yomiStyle}">${yomi}</rt></ruby>`);
         } else {
-            bare_rxp = new RegExp(kanji, 'g');
+            bare_rxp = new RegExp(kanji + `(?![^<]*<\/rb>)`, 'g');
             furiganized[key] = furiganized[key].replace(bare_rxp, `<ruby><rb>${kanji}</rb><rt style="${yomiStyle}">${yomi}</rt></ruby>`);
         }
     }

--- a/background.js
+++ b/background.js
@@ -298,6 +298,15 @@ browser.runtime.onMessage.addListener(
                 var numeric_yomi = EXCEPTIONS;
                 var numeric_kanji = '';
 
+                // sort tagged in order to add furigana 
+                // for the longer Kanji series first
+                tagged.sort(function(a, b) {
+                    var kanjiRegExp = /([\u4E00-\u9FFF]*)/;
+                    var aKanji = a.surface.match(kanjiRegExp)[0];
+                    var bKanji = b.surface.match(kanjiRegExp)[0];
+                    return bKanji.length - aKanji.length;
+                })
+
                 tagged.forEach(function(t) {
                     if (t.surface.match(/[\u3400-\u9FBF]/)) {
                         kanji = t.surface;

--- a/background.js
+++ b/background.js
@@ -240,7 +240,11 @@ function addRuby(furiganized, kanji, yomi, key, processed, yomiStyle) {
             // furiganized[key] = furiganized[key].replace(rubyPatt, `<ruby><rb>${kanji}</rb><rp>(</rp><rt style="${yomiStyle}">${yomi}</rt><rp>)</rp></ruby>`);
             furiganized[key] = furiganized[key].replace(rubyPatt, `<ruby><rb>${kanji}</rb><rt style="${yomiStyle}">${yomi}</rt></ruby>`);
         } else {
-            bare_rxp = new RegExp(kanji + `(?![^<]*<\/rb>)`, 'g');
+            if (JSON.parse(localStorage.getItem("prevent_splitting_consecutive_kanjis"))) {
+                bare_rxp = new RegExp(kanji + `(?![^<]*<\/rb>)`, 'g');
+            } else {
+                bare_rxp = new RegExp(kanji, 'g');
+            }
             furiganized[key] = furiganized[key].replace(bare_rxp, `<ruby><rb>${kanji}</rb><rt style="${yomiStyle}">${yomi}</rt></ruby>`);
         }
     }
@@ -298,14 +302,16 @@ browser.runtime.onMessage.addListener(
                 var numeric_yomi = EXCEPTIONS;
                 var numeric_kanji = '';
 
-                // sort tagged in order to add furigana 
-                // for the longer Kanji series first
-                tagged.sort(function(a, b) {
-                    var kanjiRegExp = /([\u4E00-\u9FFF]*)/;
-                    var aKanji = a.surface.match(kanjiRegExp)[0];
-                    var bKanji = b.surface.match(kanjiRegExp)[0];
-                    return bKanji.length - aKanji.length;
-                })
+                if (JSON.parse(localStorage.getItem("prevent_splitting_consecutive_kanjis"))) {
+                    // sort tagged in order to add furigana 
+                    // for the longer Kanji series first
+                    tagged.sort(function(a, b) {
+                        var kanjiRegExp = /([\u4E00-\u9FFF]*)/;
+                        var aKanji = a.surface.match(kanjiRegExp)[0];
+                        var bKanji = b.surface.match(kanjiRegExp)[0];
+                        return bKanji.length - aKanji.length;
+                    });
+                }
 
                 tagged.forEach(function(t) {
                     if (t.surface.match(/[\u3400-\u9FBF]/)) {

--- a/user_cp/options.html
+++ b/user_cp/options.html
@@ -37,6 +37,9 @@
 		<p><label><input type="checkbox" id="auto_start"/> <code>beta</code> Auto-start always. <b>Not recommended.</b></label>
 	</div>
 	<div class="row">
+		<p><label><input type="checkbox" id="prevent_splitting_consecutive_kanjis"/> <code>beta</code> Prevents splitting of consecutive Kanji characters. <b>This feature is in alpha phase testing.</b></label>
+	</div>
+	<div class="row">
 		<p><label>Furigana should be displayed with <select id="furigana_display"><option value="hira">Hiragana</option><option value="kata">Katakana</option><option value="roma">Romaji</option></select></label>
 	</div>
 	<div style="margin-bottom: 14px">

--- a/user_cp/options.js
+++ b/user_cp/options.js
@@ -11,6 +11,7 @@ function initControlValues() {
         $("#watch_page_change")[0].checked = JSON.parse(localStorage.getItem("watch_page_change"));
         $("#use_mobile_floating_button")[0].checked = JSON.parse(localStorage.getItem("use_mobile_floating_button"));
 		// $("#auto_start")[0].checked = JSON.parse(localStorage.getItem("auto_start"));
+		$("#prevent_splitting_consecutive_kanjis")[0].checked = JSON.parse(localStorage.getItem("prevent_splitting_consecutive_kanjis"));
 		$("#yomi_size").val(localStorage.getItem("yomi_size"));
 		$("#yomi_color").colpick({
 			layout:'hex',
@@ -78,6 +79,14 @@ function initControlValues() {
 			if (autoStart) {
 				localStorage.setItem("persistent_mode", autoStart);
 				$("#persistent_mode").prop('checked', autoStart);
+			}
+		});
+		$("#prevent_splitting_consecutive_kanjis").bind("change", function() {
+			var preventSplittingConsecutiveKanjis = this.checked;
+			localStorage.setItem("prevent_splitting_consecutive_kanjis", preventSplittingConsecutiveKanjis);
+			if (preventSplittingConsecutiveKanjis) {
+				localStorage.setItem("prevent_splitting_consecutive_kanjis", preventSplittingConsecutiveKanjis);
+				$("#prevent_splitting_consecutive_kanjis").prop('checked', preventSplittingConsecutiveKanjis);
 			}
 		});
 		$("#yomi_size").bind("change", function() {


### PR DESCRIPTION
Some of the kanji characters that were once furiganized
are matched again to the current regular expression.
This fix will make sure that Kanji characters in
<ruby> tags will not be replaced.
To do so, a modification is made to the
regular expression for the search.

This relates #9 